### PR TITLE
The last first

### DIFF
--- a/flymake-easy.el
+++ b/flymake-easy.el
@@ -84,7 +84,7 @@ Argument LOCATION where to create the temporary copy: one of 'tempdir (default) 
 Argument WARNING-RE a pattern which identifies error messages as warnings.
 Argument INFO-RE a pattern which identifies messages as infos (supported only
 by the flymake fork at https://github.com/illusori/emacs-flymake)."
-  (let ((executable (first (funcall command-fn "dummy"))))
+  (let ((executable (car (funcall command-fn "dummy"))))
     (if (executable-find executable) ;; TODO: defer this checking
         (unless (flymake-easy-exclude-buffer-p)
           (setq flymake-easy--command-fn command-fn


### PR DESCRIPTION
I had an issue with (void function first) like in purcell/flymake-ruby#4. This should fix it, in line with 34caaed87c04f28e218e20b40ce7dd3089cab531, 1b5454c89dd47227196542cd75cb3666ec90299d.
