### PR TITLE
Add new flymake-easy--location

### DIFF
--- a/flymake-easy.el
+++ b/flymake-easy.el
@@ -37,7 +37,8 @@
 (defvar flymake-easy--command-fn nil
   "The user-specified function for building the flymake command.")
 (defvar flymake-easy--location nil
-  "Where to create the temp file when checking, one of 'tempdir or 'inplace.")
+  "Where to create the temp file when checking, one of 'tempdir, 'inplace or
+'temp-with-folder.")
 (defvar flymake-easy--extension nil
   "The canonical file name extension to use for the current file.")
 
@@ -63,6 +64,8 @@ Argument PREFIX temp file prefix, supplied by flymake."
              'flymake-easy--tempfile-in-temp-dir)
             ((eq 'inplace flymake-easy--location)
              'flymake-create-temp-inplace)
+            ((eq 'temp-with-folder flymake-easy--location)
+             'flymake-create-temp-with-folder-structure)
             (t
              (error "unknown location for flymake-easy: %s" flymake-easy--location)))))
          (command (funcall flymake-easy--command-fn tempfile)))
@@ -80,7 +83,7 @@ Argument COMMAND-FN function called to build the
    command line to run (receives filename, returns list).
 Argument ERR-LINE-PATTERNS patterns for identifying errors (see `flymake-err-line-patterns').
 Argument EXTENSION a canonical extension for this type of source file, e.g. \"rb\".
-Argument LOCATION where to create the temporary copy: one of 'tempdir (default) or 'inplace.
+Argument LOCATION where to create the temporary copy: one of 'tempdir (default), 'inplace or 'temp-with-folder
 Argument WARNING-RE a pattern which identifies error messages as warnings.
 Argument INFO-RE a pattern which identifies messages as infos (supported only
 by the flymake fork at https://github.com/illusori/emacs-flymake)."


### PR DESCRIPTION
Hi, I pull request to add new `flymake-easy--location'

I would like to use `flymake-create-temp-with-folder-structure` function to
create a flymake java checker with flymake-easy.
I think the `flymake-create-temp-with-folder-structure` function is
not problem because `flymake-simple-make-java-init` is already using
this function like this:

``` lisp
(defun flymake-simple-make-java-init ()
  (flymake-simple-make-init-impl 'flymake-create-temp-with-folder-structure nil nil "Makefile" 'flymake-get-make-cmdline))
```

Could you merge this pull request?
