### PR TITLE
fix: Avoid recursive initialization

### DIFF
--- a/flymake-easy.el
+++ b/flymake-easy.el
@@ -103,7 +103,8 @@ by the flymake fork at https://github.com/illusori/emacs-flymake)."
           (when (boundp 'flymake-info-line-regexp)
             (set (make-local-variable 'flymake-info-line-regexp)
                  (or info-re "^[iI]nfo")))
-          (flymake-mode t))
+          (unless flymake-mode
+            (flymake-mode t)))
       (message "Not enabling flymake: '%s' program not found" executable))))
 
 ;; Internal overrides for flymake


### PR DESCRIPTION
I want to setup the checker only when `flymake` is loaded; therefore, I have this:

```elisp
(use-package flymake-ruby :hook (flymake-mode . flymake-ruby-load))
```

But this will cause infinite recursion due to https://github.com/purcell/flymake-easy/blob/de41ea49503f71f997e5c359a2ad08df696c0147/flymake-easy.el#L106

This patch avoid this.