### PR TITLE
Use a valid Version

### DIFF
--- a/flymake-easy.el
+++ b/flymake-easy.el
@@ -4,7 +4,7 @@
 
 ;; Author: Steve Purcell <steve@sanityinc.com>
 ;; URL: https://github.com/purcell/flymake-easy
-;; Version: DEV
+;; Version: 0
 ;; Keywords: convenience, internal
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Change "Version: DEV" to "Version: 0"

This solves a problem with the Elpaca package manager. See https://github.com/progfolio/elpaca/issues/321#issuecomment-2185399240

I chose "Version: 0" to match https://github.com/purcell/flymake-ruby/blob/6c320c6fb686c5223bf975cc35178ad6b195e073/flymake-ruby.el#L7